### PR TITLE
Support multiple stacks in a single account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ cdk.out
 !lambda/handler.js
 !lambda/config.example.js
 !lambda/config.d.ts
+!lambda/lib/metrics.js
+!lambda/lib/filterSpam.js

--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ This is a CDK-ification of [this project](https://github.com/arithmetric/aws-lam
 1. `npx cdk synth`
 1. `npx cdk deploy --require-approval never`
 1. Go into [your SES Console](https://console.aws.amazon.com/ses/home?region=us-east-1#receipt-rules:) and set your new RuleSet as Active
+  1. If you have an existing RuleSet, clone it as backup then copy your new rules into your existing rule set manually.
 1. [Verify the email address(es) that you're forwarding to](https://console.aws.amazon.com/ses/home?region=us-east-1#verified-senders-email:)
 1. Send a test email to your recipient, and it should forward correctly

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ This is a CDK-ification of [this project](https://github.com/arithmetric/aws-lam
 
 # Steps
 
+## Initial Deployment
+
 1. [Buy a domain](https://console.aws.amazon.com/route53/home#DomainRegistration:)
 1. [Verify your domain in SES](https://console.aws.amazon.com/ses/home?region=us-east-1#verified-senders-domain:)
 1. clone the repo
@@ -10,7 +12,15 @@ This is a CDK-ification of [this project](https://github.com/arithmetric/aws-lam
 1. `yarn`
 1. `npx cdk synth`
 1. `npx cdk deploy --require-approval never`
-1. Go into [your SES Console](https://console.aws.amazon.com/ses/home?region=us-east-1#receipt-rules:) and set your new RuleSet as Active
-  1. If you have an existing RuleSet, clone it as backup then copy your new rules into your existing rule set manually.
+1. Go into [your SES Console](https://console.aws.amazon.com/ses/home?region=us-east-1#receipt-rules:) and set your new RuleSet as Active. If you have an existing RuleSet, clone it as backup then copy your new rules into your existing rule set manually.
 1. [Verify the email address(es) that you're forwarding to](https://console.aws.amazon.com/ses/home?region=us-east-1#verified-senders-email:)
 1. Send a test email to your recipient, and it should forward correctly
+
+## Updates
+After pulling down a code update, re-run the deployment command:
+1. `npx cdk deploy --require-approval never`
+1. If you have only modified the lambda, then you are done.  If you have modified any CDK or related configuration that changes the SES rule set, then take the following manual steps:
+1. Go into [your SES Console](https://console.aws.amazon.com/ses/home?region=us-east-1#receipt-rules:), locate your rule and copy it into your active rule set. You may have to change the name, to copy2, etc.
+1. Open your active rule set, enable the new rule you just copied, then disable the old rule.
+
+

--- a/bin/ses.ts
+++ b/bin/ses.ts
@@ -2,6 +2,7 @@
 import 'source-map-support/register';
 import * as cdk from '@aws-cdk/core';
 import { SesStack } from '../lib/ses-stack';
+import { config } from "../lambda/config";
 
 const app = new cdk.App();
-new SesStack(app, 'StubMinerSesStack');
+new SesStack(app, `SesForwarder${config.project}`);

--- a/lambda/config.d.ts
+++ b/lambda/config.d.ts
@@ -16,6 +16,8 @@ interface Config {
   subjectPrefix: string;
   allowPlusSign: boolean;
   spamFilter: SpamFilterOption;
+  subjectFilterKeywords: string[];
+  blockedRecipients: string[];
   forwardMapping: ForwardMapping;
 }
 

--- a/lambda/config.d.ts
+++ b/lambda/config.d.ts
@@ -2,6 +2,12 @@ interface ForwardMapping {
   [key: string]: string[];
 }
 
+export declare const enum SpamFilterOption {
+  NONE,
+  DEFAULT,
+  CUSTOM
+}
+
 interface Config {
   project: string;
   recipient: string;
@@ -9,6 +15,7 @@ interface Config {
   emailKeyPrefix: string;
   subjectPrefix: string;
   allowPlusSign: boolean;
+  spamFilter: SpamFilterOption;
   forwardMapping: ForwardMapping;
 }
 

--- a/lambda/config.d.ts
+++ b/lambda/config.d.ts
@@ -10,6 +10,7 @@ export declare const enum SpamFilterOption {
 
 interface Config {
   project: string;
+  domain: string;
   recipient: string;
   headerValue: string;
   emailKeyPrefix: string;

--- a/lambda/config.example.js
+++ b/lambda/config.example.js
@@ -1,10 +1,47 @@
+// This is an example configuration file.
+// Copy it to `config.js` and change the values below.
+
 exports.config = {
+  // 'project' - A short identifier string used in naming AWS resources
   project: "MyProject",
+
+  // 'recipient' - Forwarded emails will come from this verified address
   recipient: "contact@example.com",
-  headerValue: "example",
+
+  // 'headerValue' - Value added to a header named 'X-Special-Header'
+  headerValue: "forwarded",
+
+  // 'emailKeyPrefix' - S3 key name prefix where SES stores email.
+  //  Include the trailing slash.
   emailKeyPrefix: "emails/",
+
+  // 'subjectPrefix' - Forwarded email subjects will contain this string.
   subjectPrefix: "",
+
+  // 'allowPlusSign' - Enables support for plus sign suffixes on email addresses.
+  //   If set to `true`, the username/mailbox part of an email address is parsed
+  //   to remove anything after a plus sign. For example, an email sent to
+  //   `example+test@example.com` would be treated as if it was sent to
+  //   `example@example.com`.
   allowPlusSign: true,
+
+  // 'spamFilter' - Choose between spam filter options:
+  //  0 = None, good for initial setup and troubleshooting email receipt.
+  //  1 = Default, uses the `dropSpam` singleton lambda defined by CDK.
+  //  2 = Custom, uses the lambda in this project.
+  spamFilter: 2,  // 0 = None, 1 = Default, 2 = Custom
+
+  //  'forwardMapping' - Object where the key is the lowercase email address from
+  //   which to forward and the value is an array of email addresses to which to
+  //   send the message.
+  //
+  //   To match all email addresses on a domain, use a key without the name part
+  //   of an email address before the "at" symbol (i.e. `@example.com`).
+  //
+  //   To match a mailbox name on all domains, use a key without the "at" symbol
+  //   and domain part of an email address (i.e. `info`).
+  //
+  //   To match all email addresses matching no other mapping, use "@" as a key.
   forwardMapping: {
     "info@example.com": ["example.john@example.com", "example.jen@example.com"],
     "abuse@example.com": ["example.jim@example.com"],

--- a/lambda/config.example.js
+++ b/lambda/config.example.js
@@ -5,6 +5,9 @@ exports.config = {
   // 'project' - A short identifier string used in naming AWS resources
   project: "MyProject",
 
+  // 'domain' - The domain to handle emails for.
+  domain: "example.com",
+
   // 'recipient' - Forwarded emails will come from this address. It needs to
   //   have been verified in Amazon SES as a sender, and be part of a verified
   //   SES domain.

--- a/lambda/config.example.js
+++ b/lambda/config.example.js
@@ -5,7 +5,9 @@ exports.config = {
   // 'project' - A short identifier string used in naming AWS resources
   project: "MyProject",
 
-  // 'recipient' - Forwarded emails will come from this verified address
+  // 'recipient' - Forwarded emails will come from this address. It needs to
+  //   have been verified in Amazon SES as a sender, and be part of a verified
+  //   SES domain.
   recipient: "contact@example.com",
 
   // 'headerValue' - Value added to a header named 'X-Special-Header'
@@ -30,6 +32,21 @@ exports.config = {
   //  1 = Default, uses the `dropSpam` singleton lambda defined by CDK.
   //  2 = Custom, uses the lambda in this project.
   spamFilter: 2,  // 0 = None, 1 = Default, 2 = Custom
+
+  // List of keywords to scan subjects for.  The match is case-insensitive, but
+  // spam metric names will appear as cased here. Examples of common spam terms:
+  subjectFilterKeywords: [
+    'Viagra',
+    'Kamagra',
+    'Levitra',
+    'Keranique',
+    'Cialis'
+  ],
+
+  // List of target recipients to block
+  blockedRecipients: [
+    'spam@example.com'
+  ],
 
   //  'forwardMapping' - Object where the key is the lowercase email address from
   //   which to forward and the value is an array of email addresses to which to

--- a/lambda/lib/filterSpam.js
+++ b/lambda/lib/filterSpam.js
@@ -1,0 +1,115 @@
+const AWS = require("aws-sdk");
+const config = require("../config.js");
+const { emitMetric, emitSpamMetric }  = require("./metrics.js");
+
+const spamKey = "SPAM";
+
+/**
+ * Filters out spam, if custom filter is enabled in config.
+ * Some basic filters are included below.
+ * To add more custom filters:
+ * 1. Create a function that emits metrics and returns true if spam is found.
+ * 2. Add a  call to your new function in the list below.
+ * 3. Consider contributing this back to the project in a PR!
+ */
+function filterSpam(data) {
+  let spam = false; // Flag to set by one or more of the filter checks.
+
+  // Only check for spam to drop if custom filter is configured
+  if (config.config.spamFilter == 2) {
+    console.log('Custom Spam Filter is enabled.  Running filters...');
+
+    // Get the SES notification object from the data event
+    const sesNotification = data.event.Records[0].ses;
+    console.log("SES Notification:\n", JSON.stringify(sesNotification, null, 2));
+
+    // Run through a series of filters.
+    if(filterBySESReceiptVerdicts(sesNotification.receipt)) spam = true;
+    if(filterBySubjectKeyword(sesNotification.mail.commonHeaders.subject)) spam = true;
+    if(filterByTargetRecipient(sesNotification.mail.destination[0])) spam = true;
+  }
+
+  // If the spam flag is still not set after all the spam filters, then forward the email.
+  if (!spam) {
+    return Promise.resolve(data);
+  } else {
+    // If the spam flag is set by any of the spam filters, then reject the promise to stop the forward.
+    data.log({
+      message: "Dropped Spam.",
+      level: "error",
+      event: JSON.stringify(data.event)
+    });
+    return Promise.reject(new Error(spamKey));
+  }
+}
+
+
+/**
+ * Filter By SES Receipt Verdicts
+ * The following logic is from AWS Docs and is also found in the default CDK dropSpam implementation.
+ * This function has the same impact as choosing spamFilter config = 1 = Default
+ * Docs:  https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-lambda-example-functions.html
+ **/
+function filterBySESReceiptVerdicts(sesReceipt) {
+  console.log("filterBySESverdicts");
+  const typeName = 'SESReceiptVerdict';
+  let spam = false;
+  if (sesReceipt.spfVerdict.status === 'FAIL') spam = logSpam(typeName, 'Sender Policy Framework (SPF)');
+  if (sesReceipt.dkimVerdict.status === 'FAIL') spam = logSpam(typeName, 'DomainKeys Identified Mail (DKIM)');
+  if (sesReceipt.spamVerdict.status === 'FAIL') spam = logSpam(typeName, 'AWS Spam Verdict');
+  if (sesReceipt.virusVerdict.status === 'FAIL') spam = logSpam(typeName, 'AWS Virus Verdict');
+  return spam;
+}
+
+
+/**
+ * Filter by Subject Keyword
+ * Given an email subject, tag it as spam if it contains any configured keywords.
+ **/
+function filterBySubjectKeyword(subject) {
+  console.log("filterBySubject");
+  const typeName = 'SubjectKeyword';
+  let spam = false;
+
+  for (let i = 0; i < config.config.subjectFilterKeywords.length; i++) {
+    const keyword = config.config.subjectFilterKeywords[i];
+    if (subject.toLowerCase().includes(keyword.toLowerCase())) spam = logSpam(typeName, keyword);
+  }
+
+  return spam;
+}
+
+
+/**
+ * Filter By Target Recipient will check the To: email value and drop any configured addresses.
+ * Use this if you want to give an email to someone you know will spam you (games, conferences).
+ **/
+function filterByTargetRecipient(recipientEmail) {
+  console.log("filterByTarget");
+  const typeName = 'TargetRecipient';
+  let spam = false;
+
+  for (const recipient of config.config.blockedRecipients) {
+    if (recipientEmail === recipient) spam = logSpam(typeName, recipient.replace('@', '.'));
+  }
+
+  return spam;
+}
+
+
+/**
+ * Log Spam emits a metric and returns true, to easily set the spam flag.
+ * The intent is to record metrics for every reason an email is determined to be spam.
+ **/
+function logSpam(type, term) {
+  console.log(`Logging spam, type=${type}, term=${term}`);
+  emitSpamMetric(type, term);
+  return true;
+}
+
+
+module.exports = {
+    filterSpam,
+    spamKey
+};
+

--- a/lambda/lib/metrics.js
+++ b/lambda/lib/metrics.js
@@ -1,0 +1,104 @@
+var config = require("../config.js");
+
+const NAMESPACE_ROOT = `${config.config.project}/SESForwarder`;
+
+/**
+ * emitMetric to CloudWatch using Embedded Metric Format (EMF) of logging from Lambda.  For example:
+ *
+ * {"_aws":{"Timestamp":1611034887493,"CloudWatchMetrics":[{"Namespace":"MyDomain/SESForwarder/Spam",
+ * "Dimensions":[["Type"]],"Metrics":[{"Name":"Viagra","Unit":"Count"}]}]},"Viagra":1,"Type":"SubjectKeyword"}
+ *
+ * See: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html
+ * Also: https://aws.amazon.com/blogs/mt/lowering-costs-and-focusing-on-our-customers-with-amazon-cloudwatch-embedded-custom-metrics/
+ *
+ * Params:
+ *   metricName is a string name of metric.
+ *
+ *   dimensions is an array of dimension objets, following cloudwatch.putMetric schema.
+ *     For example:
+ *
+ *     const dimensions = [
+ *       {
+ *         Name: 'MyDimensionName',
+ *         Value: 'MyDimensionValue'
+ *       }
+ *     ];
+ *
+ *    namespace is a string of the CloudWatch namespace that metrics will be emitted under.
+ */
+function emitMetric(metricName, dimensions= [], namespace = NAMESPACE_ROOT) {
+  // The EMF log spec puts dimension keys inside the schema and values outside at root level.
+  // Build up a list of just the keys.
+  let dimensionKeys = [], dimensionsArray = [];
+  for (const dimension of dimensions){
+    dimensionKeys.push(dimension.Name);
+  }
+
+  // Create the EMF log structure following the spec.
+  let embeddedMetricLog = {
+    "_aws": {
+        "Timestamp": Date.now(),
+        "CloudWatchMetrics": [
+            {
+                "Namespace": namespace,
+                "Dimensions": [ dimensionKeys ],
+                "Metrics": [
+                    {
+                        "Name": metricName,
+                        "Unit": "Count"
+                    }
+                ]
+            }
+        ]
+    }
+  };
+
+  // Add the metric name and count as a root element, following EMF spec
+  embeddedMetricLog[metricName] = 1.0;
+
+  // Add the dimension mapping as root elements, following EMF spec.
+  for (const dimension of dimensions){
+    embeddedMetricLog[dimension.Name] = dimension.Value;
+  }
+
+  // When executing in Lambda, EMF spec just needs to be emitted as std output.
+  console.log(JSON.stringify(embeddedMetricLog));
+
+  // Return true to signal success logging metric
+  return true;
+}
+
+
+/**
+ * emitSpamMetric to CloudWatch using consistent namespace.
+ * Type is the type of spam reason, usually per filter type.
+ * Term is the specific term of this type that triggered the spam flag.
+ */
+function emitSpamMetric(type, term) {
+  const dimensions = [
+    {
+      Name: 'Type',
+      Value: type
+    },
+  ];
+
+  return emitMetric(term, dimensions, `${NAMESPACE_ROOT}/Spam`);
+}
+
+
+/**
+ * emitResultMetric to CloudWatch using consistent namespace.
+ * Result Examples: Success, Error, Spam, Other...
+ */
+function emitResultMetric(result) {
+  const dimensions = [];
+  return emitMetric(result, dimensions, `${NAMESPACE_ROOT}/Result`);
+}
+
+
+module.exports = {
+  emitMetric,
+  emitSpamMetric,
+  emitResultMetric
+};
+

--- a/lib/ses-stack.ts
+++ b/lib/ses-stack.ts
@@ -92,6 +92,7 @@ export class SesStack extends cdk.Stack {
         title: 'Total Incoming',
         width: 6,
         height: 3,
+        setPeriodToTimeRange: true,
         metrics: [new cloudwatch.Metric({
             namespace: "AWS/Lambda",
             metricName: 'Invocations',
@@ -107,6 +108,7 @@ export class SesStack extends cdk.Stack {
         title: 'Total Dropped',
         width: 6,
         height: 3,
+        setPeriodToTimeRange: true,
         metrics: [new cloudwatch.Metric({
             namespace: `${config.project}/SESForwarder/Result`,
             metricName: 'Spam',
@@ -119,6 +121,7 @@ export class SesStack extends cdk.Stack {
         title: 'Total Errors',
         width: 6,
         height: 3,
+        setPeriodToTimeRange: true,
         metrics: [new cloudwatch.Metric({
             namespace: `${config.project}/SESForwarder/Result`,
             metricName: 'Error',
@@ -131,6 +134,7 @@ export class SesStack extends cdk.Stack {
         title: 'Total Forwarded',
         width: 6,
         height: 3,
+        setPeriodToTimeRange: true,
         metrics: [new cloudwatch.Metric({
             namespace: `${config.project}/SESForwarder/Result`,
             metricName: 'Success',

--- a/lib/ses-stack.ts
+++ b/lib/ses-stack.ts
@@ -4,6 +4,7 @@ import lambda = require("@aws-cdk/aws-lambda");
 import s3 = require("@aws-cdk/aws-s3");
 import ses = require("@aws-cdk/aws-ses");
 import actions = require("@aws-cdk/aws-ses-actions");
+import cloudwatch = require('@aws-cdk/aws-cloudwatch');
 import path = require("path");
 
 import { SpamFilterOption, config } from "../lambda/config";
@@ -14,9 +15,10 @@ export class SesStack extends cdk.Stack {
 
     const bucket = new s3.Bucket(this, `${config.project}SESBucket`);
 
-    const func = new lambda.Function(this, `${config.project}SESForwarder`, {
+    const forwarderLambda = new lambda.Function(this, `${config.project}SESForwarder`, {
       runtime: lambda.Runtime.NODEJS_12_X,
       handler: "handler.handler",
+      functionName: `${config.project}SESForwarder`,
       code: lambda.Code.fromAsset(path.join(__dirname, "../lambda")),
       environment: {
         BUCKETNAME: bucket.bucketName
@@ -25,7 +27,7 @@ export class SesStack extends cdk.Stack {
       memorySize: 128
     });
 
-    const lambdaRole = func.role as iam.Role;
+    const lambdaRole = forwarderLambda.role as iam.Role;
 
     const policy = new iam.Policy(this, `${config.project}SESPolicy`);
 
@@ -70,12 +72,173 @@ export class SesStack extends cdk.Stack {
               bucket,
               objectKeyPrefix: config.emailKeyPrefix
             }),
-            new actions.Lambda({ function: func })
+            new actions.Lambda({ function: forwarderLambda })
           ]
         }
       ]
     };
 
     new ses.ReceiptRuleSet(this, `${config.project}RuleSet`, ruleSetProperties);
+
+
+    /* Define a CloudWatch Metrics Dashboard */
+
+    // Total Incoming
+    let totalIncomingWidget = new cloudwatch.SingleValueWidget({
+        title: 'Total Incoming',
+        width: 6,
+        height: 3,
+        metrics: [new cloudwatch.Metric({
+            namespace: "AWS/Lambda",
+            metricName: 'Invocations',
+            dimensions: {
+                FunctionName: forwarderLambda.functionName
+            },
+            statistic: 'Sum'
+        })]
+    });
+
+    // Total Dropped
+    let totalDroppedWidget = new cloudwatch.SingleValueWidget({
+        title: 'Total Dropped',
+        width: 6,
+        height: 3,
+        metrics: [new cloudwatch.Metric({
+            namespace: `${config.project}/SESForwarder/Result`,
+            metricName: 'Spam',
+            statistic: 'Sum'
+        })]
+    });
+
+    // Total Errors
+    let totalErrorsWidget = new cloudwatch.SingleValueWidget({
+        title: 'Total Errors',
+        width: 6,
+        height: 3,
+        metrics: [new cloudwatch.Metric({
+            namespace: `${config.project}/SESForwarder/Result`,
+            metricName: 'Error',
+            statistic: 'Sum'
+        })]
+    });
+
+    // Total Forwarded
+    let totalForwardedWidget = new cloudwatch.SingleValueWidget({
+        title: 'Total Forwarded',
+        width: 6,
+        height: 3,
+        metrics: [new cloudwatch.Metric({
+            namespace: `${config.project}/SESForwarder/Result`,
+            metricName: 'Success',
+            statistic: 'Sum'
+        })]
+    });
+
+    // Lambda Invocations and Duration
+    const executionsWidget = new cloudwatch.GraphWidget({
+        title: 'Forwarder Executions',
+        width: 12,
+        height: 3,
+        left: [new cloudwatch.Metric({
+            namespace: 'AWS/Lambda',
+            metricName: 'Invocations',
+            dimensions: {
+                FunctionName: forwarderLambda.functionName
+            },
+            statistic: 'Sum'
+        })],
+        right: [new cloudwatch.Metric({
+            namespace: 'AWS/Lambda',
+            metricName: 'Duration',
+            dimensions: {
+                FunctionName: forwarderLambda.functionName
+            },
+            statistic: 'Sum'
+        })],
+        rightYAxis: {
+            label: "Latency"
+        },
+    });
+
+    // Results
+    let resultWidget = new cloudwatch.GraphWidget({
+        title: 'Forwarder Results',
+        width: 12,
+        height: 3,
+        stacked: true,
+        left: [new cloudwatch.Metric({
+            namespace: `${config.project}/SESForwarder/Result`,
+            metricName: 'Error',
+            statistic: 'Sum'
+        }),
+        new cloudwatch.Metric({
+            namespace: `${config.project}/SESForwarder/Result`,
+            metricName: 'Spam',
+            statistic: 'Sum'
+        }),
+        new cloudwatch.Metric({
+            namespace: `${config.project}/SESForwarder/Result`,
+            metricName: 'Success',
+            statistic: 'Sum'
+        })]
+    });
+
+    // Spam Tags
+    let spamWidget = new cloudwatch.GraphWidget({
+        title: 'Spam Tags by Type',
+        width: 12,
+        height: 9,
+        left: [new cloudwatch.MathExpression({
+            expression: `SEARCH('{${config.project}/SESForwarder/Spam,Type}', 'Sum', 300)`,
+            usingMetrics: { },
+            label: ' '
+        })]
+    });
+
+    // Results
+    let sesWidget = new cloudwatch.GraphWidget({
+        title: 'Total Account SES Sends',
+        width: 12,
+        height: 3,
+        stacked: true,
+        left: [new cloudwatch.Metric({
+            namespace: 'AWS/SES',
+            metricName: 'Send',
+            statistic: 'Sum'
+        })]
+    });
+
+    // Recent logs
+    let queryLinesList = ['fields @timestamp, mail.commonHeaders.from.0, mail.destination.0, mail.commonHeaders.subject, ispresent(mail.commonHeaders.from.0) as fw'];
+    queryLinesList.push('filter fw != 0');
+    queryLinesList.push('sort @timestamp desc');
+    queryLinesList.push('limit 10');
+    let logWidget = new cloudwatch.LogQueryWidget({
+        title: 'Recent Forwarder Logs',
+        logGroupNames: [forwarderLambda.logGroup.logGroupName],
+        queryLines: queryLinesList,
+        width: 24,
+        height: 6
+    });
+
+    const emailDashboard = new cloudwatch.Dashboard(this, `${config.project}EmailDashboard`, {
+      dashboardName: `${config.project}-Email-Dashboard`,
+      widgets: [
+        [
+          new cloudwatch.Column(totalIncomingWidget),
+          new cloudwatch.Column(totalDroppedWidget),
+          new cloudwatch.Column(totalErrorsWidget),
+          new cloudwatch.Column(totalForwardedWidget),
+        ],
+        [
+          new cloudwatch.Column(executionsWidget, resultWidget, sesWidget),
+          new cloudwatch.Column(spamWidget),
+        ],
+        [
+          logWidget
+        ]
+      ]
+    });
+
   }
 }

--- a/lib/ses-stack.ts
+++ b/lib/ses-stack.ts
@@ -13,7 +13,22 @@ export class SesStack extends cdk.Stack {
   constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    const bucket = new s3.Bucket(this, `${config.project}SESBucket`);
+    const bucket = new s3.Bucket(this, `${config.project}SESBucket`, {
+        lifecycleRules: [
+          {
+            transitions: [
+                {
+                    storageClass: s3.StorageClass.INFREQUENT_ACCESS,
+                    transitionAfter: cdk.Duration.days(30),
+                },
+                {
+                    storageClass: s3.StorageClass.GLACIER,
+                    transitionAfter: cdk.Duration.days(90),
+                },
+            ],
+          },
+        ],
+    });
 
     const forwarderLambda = new lambda.Function(this, `${config.project}SESForwarder`, {
       runtime: lambda.Runtime.NODEJS_12_X,

--- a/lib/ses-stack.ts
+++ b/lib/ses-stack.ts
@@ -63,6 +63,7 @@ export class SesStack extends cdk.Stack {
       rules: [
         {
           enabled: true,
+          recipients: [ `.${config.domain}`, config.domain ],
           actions: [
             new actions.AddHeader({
               name: "X-Special-Header",
@@ -72,7 +73,10 @@ export class SesStack extends cdk.Stack {
               bucket,
               objectKeyPrefix: config.emailKeyPrefix
             }),
-            new actions.Lambda({ function: forwarderLambda })
+            new actions.Lambda({
+              function: forwarderLambda
+            }),
+            new actions.Stop({})
           ]
         }
       ]

--- a/lib/ses-stack.ts
+++ b/lib/ses-stack.ts
@@ -6,7 +6,7 @@ import ses = require("@aws-cdk/aws-ses");
 import actions = require("@aws-cdk/aws-ses-actions");
 import path = require("path");
 
-import { config } from "../lambda/config";
+import { SpamFilterOption, config } from "../lambda/config";
 
 export class SesStack extends cdk.Stack {
   constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
@@ -55,12 +55,12 @@ export class SesStack extends cdk.Stack {
     );
     lambdaRole.attachInlinePolicy(policy);
 
-    new ses.ReceiptRuleSet(this, `${config.project}RuleSet`, {
-      dropSpam: true,
+    if (config.spamFilter == SpamFilterOption.NONE) console.warn("Warning: you are not using any spam filter!");
+    const ruleSetProperties = {
+      dropSpam: config.spamFilter == SpamFilterOption.DEFAULT ? true : false,
       rules: [
         {
           enabled: true,
-          recipients: [config.recipient],
           actions: [
             new actions.AddHeader({
               name: "X-Special-Header",
@@ -74,6 +74,8 @@ export class SesStack extends cdk.Stack {
           ]
         }
       ]
-    });
+    };
+
+    new ses.ReceiptRuleSet(this, `${config.project}RuleSet`, ruleSetProperties);
   }
 }


### PR DESCRIPTION
This is to add ability to support deploying multiple stacks in a single account, which is useful for managing multiple domains, and testing changes on one before promoting them to another.

Changes include:

- Include project name in stack name (currently set to StubMiner)
- Clarify instructions on how to merge SES RuleSets.