### PR TITLE
Add spam filters: sender blocklist, domain blocklist, brand impersonation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ cdk.out
 !lambda/handler.js
 !lambda/config.example.js
 !lambda/config.d.ts
+!lambda/lib/metrics.js
+!lambda/lib/filterSpam.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+CDK project that deploys an AWS Lambda-based SES email forwarder. Based on [aws-lambda-ses-forwarder](https://github.com/arithmetric/aws-lambda-ses-forwarder), wrapped in CDK infrastructure.
+
+## Commands
+
+- `yarn` — install dependencies
+- `yarn build` — compile TypeScript (`tsc`)
+- `yarn test` — run tests (`jest`)
+- `npx cdk synth` — synthesize CloudFormation template
+- `npx cdk deploy --require-approval never` — deploy to AWS
+
+## Architecture
+
+Two layers with different languages:
+
+**CDK Infrastructure (TypeScript):** `lib/ses-stack.ts` defines the full stack — S3 bucket with lifecycle rules, Lambda function, IAM policies, SES receipt rule set, and a CloudWatch dashboard. The CDK app entry point is `bin/ses.ts`.
+
+**Lambda Runtime (plain JavaScript):** `lambda/handler.js` processes inbound SES emails through a sequential promise chain: parse SES event → filter spam → transform recipients → fetch raw email from S3 → rewrite headers (From, Reply-To, Subject, strip DKIM) → send via SES `sendRawEmail`.
+
+**Configuration:** `lambda/config.js` (gitignored, created from `config.example.js`) drives both layers — the CDK stack reads it for resource naming/domain setup, and the Lambda reads it at runtime for forwarding rules. The config type is declared in `lambda/config.d.ts`.
+
+**Spam filtering** (`lambda/lib/filterSpam.js`): Three filters run when `spamFilter=2` (Custom) — SES receipt verdicts, subject keyword matching, and blocked recipient list.
+
+**Metrics** (`lambda/lib/metrics.js`): Uses CloudWatch Embedded Metric Format (EMF) via structured `console.log` — no CloudWatch SDK calls needed from Lambda. Emits under `{project}/SESForwarder/Result` and `{project}/SESForwarder/Spam` namespaces.
+
+## Key Details
+
+- Uses AWS CDK v1 (1.44.0) — imports are per-package (`@aws-cdk/aws-lambda`, not `aws-cdk-lib`)
+- Lambda is Node.js 12.x runtime, plain JS (not transpiled from TS)
+- S3 bucket name is passed to Lambda via `BUCKETNAME` environment variable
+- SES rule set must be manually activated in the AWS console after deploy
+- The test in `test/ses.test.ts` is a snapshot-style CDK assertion (currently expects empty resources — will fail against real stack)

--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ This is a CDK-ification of [this project](https://github.com/arithmetric/aws-lam
 1. `npx cdk synth`
 1. `npx cdk deploy --require-approval never`
 1. Go into [your SES Console](https://console.aws.amazon.com/ses/home?region=us-east-1#receipt-rules:) and set your new RuleSet as Active
+  1. If you have an existing RuleSet, clone it as backup then copy your new rules into your existing rule set manually.
 1. [Verify the email address(es) that you're forwarding to](https://console.aws.amazon.com/ses/home?region=us-east-1#verified-senders-email:)
 1. Send a test email to your recipient, and it should forward correctly

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ This is a CDK-ification of [this project](https://github.com/arithmetric/aws-lam
 
 # Steps
 
+## Initial Deployment
+
 1. [Buy a domain](https://console.aws.amazon.com/route53/home#DomainRegistration:)
 1. [Verify your domain in SES](https://console.aws.amazon.com/ses/home?region=us-east-1#verified-senders-domain:)
 1. clone the repo
@@ -10,7 +12,15 @@ This is a CDK-ification of [this project](https://github.com/arithmetric/aws-lam
 1. `yarn`
 1. `npx cdk synth`
 1. `npx cdk deploy --require-approval never`
-1. Go into [your SES Console](https://console.aws.amazon.com/ses/home?region=us-east-1#receipt-rules:) and set your new RuleSet as Active
-  1. If you have an existing RuleSet, clone it as backup then copy your new rules into your existing rule set manually.
+1. Go into [your SES Console](https://console.aws.amazon.com/ses/home?region=us-east-1#receipt-rules:) and set your new RuleSet as Active. If you have an existing RuleSet, clone it as backup then copy your new rules into your existing rule set manually.
 1. [Verify the email address(es) that you're forwarding to](https://console.aws.amazon.com/ses/home?region=us-east-1#verified-senders-email:)
 1. Send a test email to your recipient, and it should forward correctly
+
+## Updates
+After pulling down a code update, re-run the deployment command:
+1. `npx cdk deploy --require-approval never`
+1. If you have only modified the lambda, then you are done.  If you have modified any CDK or related configuration that changes the SES rule set, then take the following manual steps:
+1. Go into [your SES Console](https://console.aws.amazon.com/ses/home?region=us-east-1#receipt-rules:), locate your rule and copy it into your active rule set. You may have to change the name, to copy2, etc.
+1. Open your active rule set, enable the new rule you just copied, then disable the old rule.
+
+

--- a/README.md
+++ b/README.md
@@ -23,4 +23,178 @@ After pulling down a code update, re-run the deployment command:
 1. Go into [your SES Console](https://console.aws.amazon.com/ses/home?region=us-east-1#receipt-rules:), locate your rule and copy it into your active rule set. You may have to change the name, to copy2, etc.
 1. Open your active rule set, enable the new rule you just copied, then disable the old rule.
 
+## Spam Filters
+
+When `spamFilter` is set to `2` (Custom) in config, the following filters run in order:
+
+| Filter | Config Field | What it does |
+|--------|-------------|--------------|
+| SES Receipt Verdicts | — | Drops emails that fail SPF, DKIM, spam, or virus checks |
+| Subject Keyword | `subjectFilterKeywords` | Drops emails whose subject contains a blocklisted keyword |
+| Target Recipient | `blockedRecipients` | Drops emails sent to specific honeypot/throwaway addresses |
+| Sender Domain | `blockedSenderDomains` | Drops emails from known spam-sending domains |
+| Bulk Mail Headers | `bulkMailHeaders` | Drops emails containing headers added by mass-mailer platforms (e.g. `X-Node-Mail`) |
+| Brand Impersonation | `brandKeywords` + `trustedBrandDomains` | Drops emails where the From display name contains a brand name but the sender domain isn't that brand's real domain |
+
+## Troubleshooting
+
+CloudWatch Insights queries to run against the Lambda log group (e.g. `/aws/lambda/TylerWaltsSESForwarder`).
+
+### Recent forwarded emails
+
+```
+fields @timestamp, mail.commonHeaders.from.0, mail.destination.0, mail.commonHeaders.subject, ispresent(mail.commonHeaders.from.0) as fw
+| filter fw != 0
+| sort @timestamp desc
+| limit 10
+```
+
+### Top sender domains by volume
+
+```
+fields mail.source
+| filter ispresent(mail.source)
+| parse mail.source /(?<sender_domain>@.+)$/
+| stats count() as email_count by sender_domain
+| sort email_count desc
+| limit 50
+```
+
+### Emails with bulk mail headers
+
+```
+fields @timestamp, mail.commonHeaders.from.0, mail.source
+| filter ispresent(mail.source)
+| filter @message like /X-Node-Mail/
+  or @message like /X-Delivery-Attempt-ID/
+  or @message like /X-Attachment-Ref/
+  or @message like /X-Mailer-LID/
+  or @message like /X-Campaign-ID/
+| parse mail.source /(?<sender_domain>@.+)$/
+| stats count() as bulk_count by sender_domain
+| sort bulk_count desc
+```
+
+### From display name vs sender domain mismatch
+
+Finds emails where the display name in From doesn't match the actual sending domain — ranked by volume.
+
+```
+fields mail.commonHeaders.from.0, mail.source
+| filter ispresent(mail.commonHeaders.from.0) and ispresent(mail.source)
+| parse mail.source /(?<sender_domain>[^@]+)$/ 
+| parse mail.commonHeaders.from.0 /(?<display_name>[^<]+)/
+| filter display_name not like sender_domain
+| stats count() as mismatch_count by display_name, sender_domain
+| sort mismatch_count desc
+| limit 50
+```
+
+### Top recipients receiving the most email
+
+Useful for identifying honeypot addresses getting hammered.
+
+```
+fields mail.destination.0
+| filter ispresent(mail.destination.0)
+| stats count() as email_count by mail.destination.0
+| sort email_count desc
+```
+
+### Overall volume trend (weekly)
+
+```
+fields @timestamp
+| filter ispresent(mail.source)
+| stats count() as emails by bin(1w)
+| sort @timestamp asc
+```
+
+
+-----
+
+
+Example Log Insights Output
+
+```
+@requestId 5ea3ebd0-d3bc-4dde-bb15-9322c8bc4d1c
+@timestamp 1780796520934
+mail.commonHeaders.date Sat, 6 Jun 2026 21:38:56 -0400
+mail.commonHeaders.from.0 C0stc0 Meat Special <cstcmeatspecial@ceedinary.com>
+mail.commonHeaders.messageId <b523d430.huftedaiuywmqw2nedcgvrbfhpxkvfa@ceedinary.com>
+mail.commonHeaders.replyTo.0 cstcmeatspecial@ceedinary.com
+mail.commonHeaders.returnPath cstcmeatspecial@ceedinary.com
+mail.commonHeaders.subject Thank You for Your Costco Stop, Meat Box Special
+mail.commonHeaders.to.0 adobe@tylerwalts.com
+mail.destination.0 adobe@tylerwalts.com
+mail.headers.0.name Return-Path
+mail.headers.0.value <cstcmeatspecial@ceedinary.com>
+mail.headers.1.name Received
+mail.headers.1.value from mail2.ceedinary.com (signal4107.hrillinois.com [103.27.248.101]) by inbound-smtp.us-west-2.amazonaws.com with SMTP id bjeaq8b6ultae1j07u2rjmh596k0k6japeqic601 for adobe@tylerwalts.com; Sun, 07 Jun 2026 01:38:58 +0000 (UTC)
+mail.headers.2.name Received-SPF
+mail.headers.2.value pass (spfCheck: domain of ceedinary.com designates 103.27.248.101 as permitted sender) client-ip=103.27.248.101; envelope-from=cstcmeatspecial@ceedinary.com; helo=mail2.ceedinary.com;
+mail.headers.3.name Authentication-Results
+mail.headers.3.value amazonses.com; spf=pass (spfCheck: domain of ceedinary.com designates 103.27.248.101 as permitted sender) client-ip=103.27.248.101; envelope-from=cstcmeatspecial@ceedinary.com; helo=mail2.ceedinary.com; dkim=pass header.i=@ceedinary.com; dmarc=pass header.from=ceedinary.com;
+mail.headers.4.name X-SES-RECEIPT
+mail.headers.4.value AEFBQUFBQUFBQUFIQTR5dDg4MFdvZzZ3WG5ZS0pBVFJ5Y0p6dE1NOHExUU5XQ0tMOUtXbERiTGR1Qll3Z3Nxb2RsRWhEQm5pNUphTlRDRlJSZkRQWjZzSzcvNEFQalhhNGtzVXlGOW5naW85ZXNFRTdJMmtTYVpmTFJzQkdUdnNMMDZuUGo5YXdPT2RISm9EaC9LSEhkcEhIYzM4SUNsL2t5a0xmazhGMytENUtIbkNBWTdraVczbGN6eUNIbDJwZWdIKzZpU2NiQ1loSzVxdVFyanZGYnhDN1hRa09iRVI4TXNYTE9mclI0cjBRdm9tMERHMkJXSm53VzZuRE9yMGRmNVp6TVcyYUdTU1BoQ2U0d0tXZHlxaW45Y0xsblJ2ZEc2R1ZCRTdPd0tZeE9kRDZVdy83aXV4U1lLQmZsa2UzZnBqbjNab1VBYjg9
+mail.headers.5.name X-SES-DKIM-SIGNATURE
+mail.headers.5.value a=rsa-sha256; q=dns/txt; b=YwIs+BqoqrAd4BCvxxZ8DRA3nOq56EHa2/MxZNKU+hkI+J6YnsgP1m/Ea4swCMbEse1FexgSMvIk08I3nF249aIsDP1r41oXfstLjiXa3e8q5LeZ6aZBmYFkad8YvhnAxEQknKi/02kRB1l+Dhls456plH98Rp5wQBPB+TzIDcM=; c=relaxed/simple; s=hsbnp7p3ensaochzwyq5wwmceodymuwv; d=amazonses.com; t=1780796343; v=1; bh=4Qu6GwwRj0BhAq/Q4hcfigVGt+ik3Zh32TBTRI1FQ1M=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+mail.headers.6.name DKIM-Signature
+mail.headers.6.value v=1; a=rsa-sha256; c=relaxed/relaxed; s=mtarxynztcv3m; d=ceedinary.com; h=Date:Subject:MIME-Version:Message-ID:List-Unsubscribe:Content-Type:Reply-To:From:To; i=cstcmeatspecial@ceedinary.com; bh=XoRyfstKbhWDejhh6/xiwgo/RLI6/eEHIHvF8/pb4AU=; b=Wry//2WNWa1IBXZk/UDQ2ruVEwUMIXQfLTM+N+V8I8QWGyRVF4XN+AwCf53nEzGk7CQPgWN/rtgb3KeD8NRUQI0j9/xxXm+49hHr4gfz9VdOrBD0aZf31Kr0Wp4dttstYoeru5FfsyrQqk35LxkiOTaVDx+cRFGeaaT/oMHnr7HecPLLS3ovmYUzjLGEtJPh79gRaiRsUMrP37nD4/wGd3MB29zHHYr8AXEvEqrrQc99Sb+yAkSOaHWqLGtq2vYC8sCDkvvfKYQX8/kgaydVQZEU/u7UuJsYWsOdVbqcKmU9Du6jHHdqAdy59P0g2zktcA01ZbE+WeSbI2QPMGhIcw==
+mail.headers.7.name Date
+mail.headers.7.value Sat, 6 Jun 2026 21:38:56 -0400
+mail.headers.8.name Subject
+mail.headers.8.value Thank You for Your Costco Stop, Meat Box Special
+mail.headers.9.name MIME-Version
+mail.headers.9.value 1.0
+mail.headers.10.name Message-ID
+mail.headers.10.value <b523d430.huftedaiuywmqw2nedcgvrbfhpxkvfa@ceedinary.com>
+mail.headers.11.name List-Unsubscribe
+mail.headers.11.value <https://ww1.ceedinary.com/0755236tthnexpiRnS>
+mail.headers.12.name Content-Type
+mail.headers.12.value multipart/alternative; boundary="--link._RelatedBoundary_a1hp2lbnfvcko38f93b-499592-RelatedPart"
+mail.headers.13.name Reply-To
+mail.headers.13.value cstcmeatspecial@ceedinary.com
+mail.headers.14.name From
+mail.headers.14.value C0stc0 Meat Special <cstcmeatspecial@ceedinary.com>
+mail.headers.15.name To
+mail.headers.15.value adobe@tylerwalts.com
+mail.headers.16.name List-Unsubscribe-Post
+mail.headers.16.value List-Unsubscribe=One-Click
+mail.headers.17.name X-Message-ID
+mail.headers.17.value 78e5ahr0sgpvdj6sh34bkmvdq53yqqoc5
+mail.headers.18.name X-Transport-Ref
+mail.headers.18.value 20938.McTsp.HSkcdbuCSCS
+mail.headers.19.name X-Special-Header
+mail.headers.19.value forwarded
+mail.headersTruncated 0
+mail.messageId bjeaq8b6ultae1j07u2rjmh596k0k6japeqic601
+mail.source cstcmeatspecial@ceedinary.com
+mail.timestamp 2026-06-07T01:38:58.491Z
+receipt.action.functionArn arn:aws:lambda:us-west-2:680397041807:function:TylerWaltsSESForwarder
+receipt.action.invocationType Event
+receipt.action.type Lambda
+receipt.dkimVerdict.status PASS
+receipt.dmarcVerdict.status PASS
+receipt.processingTimeMillis 5002
+receipt.recipients.0 adobe@tylerwalts.com
+receipt.spamVerdict.status DISABLED
+receipt.spfVerdict.status PASS
+receipt.timestamp 2026-06-07T01:38:58.491Z
+receipt.virusVerdict.status DISABLED
+```
+
+Fields of Interest
+
+```
+mail.commonHeaders.from.0
+mail.commonHeaders.replyTo.0
+mail.commonHeaders.subject
+mail.commonHeaders.to.0
+mail.destination.0
+mail.headers.8.name
+mail.headers.8.value
+mail.source
+receipt.recipients.0
+```
 

--- a/bin/ses.ts
+++ b/bin/ses.ts
@@ -2,6 +2,7 @@
 import 'source-map-support/register';
 import * as cdk from '@aws-cdk/core';
 import { SesStack } from '../lib/ses-stack';
+import { config } from "../lambda/config";
 
 const app = new cdk.App();
-new SesStack(app, 'StubMinerSesStack');
+new SesStack(app, `SesForwarder${config.project}`);

--- a/lambda/config.d.ts
+++ b/lambda/config.d.ts
@@ -16,6 +16,8 @@ interface Config {
   subjectPrefix: string;
   allowPlusSign: boolean;
   spamFilter: SpamFilterOption;
+  subjectFilterKeywords: string[];
+  blockedRecipients: string[];
   forwardMapping: ForwardMapping;
 }
 

--- a/lambda/config.d.ts
+++ b/lambda/config.d.ts
@@ -2,6 +2,12 @@ interface ForwardMapping {
   [key: string]: string[];
 }
 
+export declare const enum SpamFilterOption {
+  NONE,
+  DEFAULT,
+  CUSTOM
+}
+
 interface Config {
   project: string;
   recipient: string;
@@ -9,6 +15,7 @@ interface Config {
   emailKeyPrefix: string;
   subjectPrefix: string;
   allowPlusSign: boolean;
+  spamFilter: SpamFilterOption;
   forwardMapping: ForwardMapping;
 }
 

--- a/lambda/config.d.ts
+++ b/lambda/config.d.ts
@@ -10,6 +10,7 @@ export declare const enum SpamFilterOption {
 
 interface Config {
   project: string;
+  domain: string;
   recipient: string;
   headerValue: string;
   emailKeyPrefix: string;

--- a/lambda/config.d.ts
+++ b/lambda/config.d.ts
@@ -19,6 +19,11 @@ interface Config {
   spamFilter: SpamFilterOption;
   subjectFilterKeywords: string[];
   blockedRecipients: string[];
+  blockedSenderDomains: string[];
+  blockedSenders: string[];
+  bulkMailHeaders: string[];
+  brandKeywords: string[];
+  trustedBrandDomains: string[];
   forwardMapping: ForwardMapping;
 }
 

--- a/lambda/config.d.ts
+++ b/lambda/config.d.ts
@@ -1,30 +1,25 @@
-interface ForwardMapping {
-  [key: string]: string[];
-}
-
 export declare const enum SpamFilterOption {
-  NONE,
-  DEFAULT,
-  CUSTOM
+    NONE = 0,
+    DEFAULT = 1,
+    CUSTOM = 2
 }
-
-interface Config {
-  project: string;
-  domain: string;
-  recipient: string;
-  headerValue: string;
-  emailKeyPrefix: string;
-  subjectPrefix: string;
-  allowPlusSign: boolean;
-  spamFilter: SpamFilterOption;
-  subjectFilterKeywords: string[];
-  blockedRecipients: string[];
-  blockedSenderDomains: string[];
-  blockedSenders: string[];
-  bulkMailHeaders: string[];
-  brandKeywords: string[];
-  trustedBrandDomains: string[];
-  forwardMapping: ForwardMapping;
-}
-
-export declare const config: Config;
+export declare const config: {
+    project: string;
+    domain: string;
+    recipient: string;
+    headerValue: string;
+    emailKeyPrefix: string;
+    subjectPrefix: string;
+    allowPlusSign: boolean;
+    spamFilter: SpamFilterOption;
+    subjectFilterKeywords: string[];
+    blockedRecipients: string[];
+    blockedSenders: string[];
+    blockedSenderDomains: string[];
+    bulkMailHeaders: string[];
+    brandKeywords: string[];
+    trustedBrandDomains: string[];
+    forwardMapping: {
+        [key: string]: string[];
+    };
+};

--- a/lambda/config.example.js
+++ b/lambda/config.example.js
@@ -1,10 +1,47 @@
+// This is an example configuration file.
+// Copy it to `config.js` and change the values below.
+
 exports.config = {
+  // 'project' - A short identifier string used in naming AWS resources
   project: "MyProject",
+
+  // 'recipient' - Forwarded emails will come from this verified address
   recipient: "contact@example.com",
-  headerValue: "example",
+
+  // 'headerValue' - Value added to a header named 'X-Special-Header'
+  headerValue: "forwarded",
+
+  // 'emailKeyPrefix' - S3 key name prefix where SES stores email.
+  //  Include the trailing slash.
   emailKeyPrefix: "emails/",
+
+  // 'subjectPrefix' - Forwarded email subjects will contain this string.
   subjectPrefix: "",
+
+  // 'allowPlusSign' - Enables support for plus sign suffixes on email addresses.
+  //   If set to `true`, the username/mailbox part of an email address is parsed
+  //   to remove anything after a plus sign. For example, an email sent to
+  //   `example+test@example.com` would be treated as if it was sent to
+  //   `example@example.com`.
   allowPlusSign: true,
+
+  // 'spamFilter' - Choose between spam filter options:
+  //  0 = None, good for initial setup and troubleshooting email receipt.
+  //  1 = Default, uses the `dropSpam` singleton lambda defined by CDK.
+  //  2 = Custom, uses the lambda in this project.
+  spamFilter: 2,  // 0 = None, 1 = Default, 2 = Custom
+
+  //  'forwardMapping' - Object where the key is the lowercase email address from
+  //   which to forward and the value is an array of email addresses to which to
+  //   send the message.
+  //
+  //   To match all email addresses on a domain, use a key without the name part
+  //   of an email address before the "at" symbol (i.e. `@example.com`).
+  //
+  //   To match a mailbox name on all domains, use a key without the "at" symbol
+  //   and domain part of an email address (i.e. `info`).
+  //
+  //   To match all email addresses matching no other mapping, use "@" as a key.
   forwardMapping: {
     "info@example.com": ["example.john@example.com", "example.jen@example.com"],
     "abuse@example.com": ["example.jim@example.com"],

--- a/lambda/config.example.js
+++ b/lambda/config.example.js
@@ -5,6 +5,9 @@ exports.config = {
   // 'project' - A short identifier string used in naming AWS resources
   project: "MyProject",
 
+  // 'domain' - The domain to handle emails for.
+  domain: "example.com",
+
   // 'recipient' - Forwarded emails will come from this address. It needs to
   //   have been verified in Amazon SES as a sender, and be part of a verified
   //   SES domain.

--- a/lambda/config.example.js
+++ b/lambda/config.example.js
@@ -5,7 +5,9 @@ exports.config = {
   // 'project' - A short identifier string used in naming AWS resources
   project: "MyProject",
 
-  // 'recipient' - Forwarded emails will come from this verified address
+  // 'recipient' - Forwarded emails will come from this address. It needs to
+  //   have been verified in Amazon SES as a sender, and be part of a verified
+  //   SES domain.
   recipient: "contact@example.com",
 
   // 'headerValue' - Value added to a header named 'X-Special-Header'
@@ -30,6 +32,21 @@ exports.config = {
   //  1 = Default, uses the `dropSpam` singleton lambda defined by CDK.
   //  2 = Custom, uses the lambda in this project.
   spamFilter: 2,  // 0 = None, 1 = Default, 2 = Custom
+
+  // List of keywords to scan subjects for.  The match is case-insensitive, but
+  // spam metric names will appear as cased here. Examples of common spam terms:
+  subjectFilterKeywords: [
+    'Viagra',
+    'Kamagra',
+    'Levitra',
+    'Keranique',
+    'Cialis'
+  ],
+
+  // List of target recipients to block
+  blockedRecipients: [
+    'spam@example.com'
+  ],
 
   //  'forwardMapping' - Object where the key is the lowercase email address from
   //   which to forward and the value is an array of email addresses to which to

--- a/lambda/config.example.js
+++ b/lambda/config.example.js
@@ -43,12 +43,69 @@ exports.config = {
     'Kamagra',
     'Levitra',
     'Keranique',
-    'Cialis'
+    'Cialis',
+    'YOU PERVERT',
+    'Omaha Steak',
+    'Omaha-Steak',
+    'Ace Hardware',
+    'Walmart Points',
+    'Pittsburg Tool',
+    'BCBS Plan',
+    'Costco Visit',
+    'CVS Points',
   ],
 
   // List of target recipients to block
   blockedRecipients: [
     'spam@example.com'
+  ],
+
+  // List of sender email addresses to block (exact match against mail.source)
+  blockedSenders: [
+    'bluesoleil@tylerwalts.com',
+    'tyler@tylerwalts.com',
+    'asdflkj@tylerwalts.com',
+    'adobe@tylerwalts.com',
+    'banggood@tylerwalts.com',
+    'admin@tylerwalts.com',
+    'tinyprints@tylerwalts.com',
+    'robinhood@tylerwalts.com',
+  ],
+
+  // List of sender domains to block (matched against mail.source domain)
+  blockedSenderDomains: [
+    'cheekychillies.com',
+    'bougiebarks.com'
+  ],
+
+  // Headers that indicate bulk/mass mailers. Presence of any = spam.
+  bulkMailHeaders: [
+    'X-Node-Mail',
+    'X-Delivery-Attempt-ID',
+    'X-Attachment-Ref'
+  ],
+
+  // Brand names that spammers impersonate in the From display name.
+  // If a brand keyword appears in the display name but the sender domain
+  // is NOT in trustedBrandDomains, it's flagged as brand impersonation.
+  brandKeywords: [
+    'Harbor Freight',
+    'HarborFreight',
+    'Amazon',
+    'Walmart',
+    'Costco',
+    'PayPal',
+    'Netflix'
+  ],
+
+  // Domains that are allowed to use brand keywords in their From name.
+  trustedBrandDomains: [
+    'harborfreight.com',
+    'amazon.com',
+    'walmart.com',
+    'costco.com',
+    'paypal.com',
+    'netflix.com'
   ],
 
   //  'forwardMapping' - Object where the key is the lowercase email address from

--- a/lambda/config.example.js
+++ b/lambda/config.example.js
@@ -1,124 +1,37 @@
 // This is an example configuration file.
 // Copy it to `config.js` and change the values below.
 
+const path = require('path');
+const fs = require('fs');
+
+const configDir = path.join(__dirname, 'config');
+
+function loadList(filename) {
+  const filepath = path.join(configDir, filename);
+  return fs.readFileSync(filepath, 'utf8')
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0);
+}
+
 exports.config = {
-  // 'project' - A short identifier string used in naming AWS resources
   project: "MyProject",
-
-  // 'domain' - The domain to handle emails for.
   domain: "example.com",
-
-  // 'recipient' - Forwarded emails will come from this address. It needs to
-  //   have been verified in Amazon SES as a sender, and be part of a verified
-  //   SES domain.
   recipient: "contact@example.com",
-
-  // 'headerValue' - Value added to a header named 'X-Special-Header'
   headerValue: "forwarded",
-
-  // 'emailKeyPrefix' - S3 key name prefix where SES stores email.
-  //  Include the trailing slash.
   emailKeyPrefix: "emails/",
-
-  // 'subjectPrefix' - Forwarded email subjects will contain this string.
   subjectPrefix: "",
-
-  // 'allowPlusSign' - Enables support for plus sign suffixes on email addresses.
-  //   If set to `true`, the username/mailbox part of an email address is parsed
-  //   to remove anything after a plus sign. For example, an email sent to
-  //   `example+test@example.com` would be treated as if it was sent to
-  //   `example@example.com`.
   allowPlusSign: true,
-
-  // 'spamFilter' - Choose between spam filter options:
-  //  0 = None, good for initial setup and troubleshooting email receipt.
-  //  1 = Default, uses the `dropSpam` singleton lambda defined by CDK.
-  //  2 = Custom, uses the lambda in this project.
   spamFilter: 2,  // 0 = None, 1 = Default, 2 = Custom
 
-  // List of keywords to scan subjects for.  The match is case-insensitive, but
-  // spam metric names will appear as cased here. Examples of common spam terms:
-  subjectFilterKeywords: [
-    'Viagra',
-    'Kamagra',
-    'Levitra',
-    'Keranique',
-    'Cialis',
-    'YOU PERVERT',
-    'Omaha Steak',
-    'Omaha-Steak',
-    'Ace Hardware',
-    'Walmart Points',
-    'Pittsburg Tool',
-    'BCBS Plan',
-    'Costco Visit',
-    'CVS Points',
-  ],
+  subjectFilterKeywords: loadList('subjectFilterKeywords.txt'),
+  blockedRecipients: loadList('blockedRecipients.txt'),
+  blockedSenders: loadList('blockedSenders.txt'),
+  blockedSenderDomains: loadList('blockedSenderDomains.txt'),
+  bulkMailHeaders: loadList('bulkMailHeaders.txt'),
+  brandKeywords: loadList('brandKeywords.txt'),
+  trustedBrandDomains: loadList('trustedBrandDomains.txt'),
 
-  // List of target recipients to block
-  blockedRecipients: [
-    'spam@example.com'
-  ],
-
-  // List of sender email addresses to block (exact match against mail.source)
-  blockedSenders: [
-    'bluesoleil@tylerwalts.com',
-    'tyler@tylerwalts.com',
-    'asdflkj@tylerwalts.com',
-    'adobe@tylerwalts.com',
-    'banggood@tylerwalts.com',
-    'admin@tylerwalts.com',
-    'tinyprints@tylerwalts.com',
-    'robinhood@tylerwalts.com',
-  ],
-
-  // List of sender domains to block (matched against mail.source domain)
-  blockedSenderDomains: [
-    'cheekychillies.com',
-    'bougiebarks.com'
-  ],
-
-  // Headers that indicate bulk/mass mailers. Presence of any = spam.
-  bulkMailHeaders: [
-    'X-Node-Mail',
-    'X-Delivery-Attempt-ID',
-    'X-Attachment-Ref'
-  ],
-
-  // Brand names that spammers impersonate in the From display name.
-  // If a brand keyword appears in the display name but the sender domain
-  // is NOT in trustedBrandDomains, it's flagged as brand impersonation.
-  brandKeywords: [
-    'Harbor Freight',
-    'HarborFreight',
-    'Amazon',
-    'Walmart',
-    'Costco',
-    'PayPal',
-    'Netflix'
-  ],
-
-  // Domains that are allowed to use brand keywords in their From name.
-  trustedBrandDomains: [
-    'harborfreight.com',
-    'amazon.com',
-    'walmart.com',
-    'costco.com',
-    'paypal.com',
-    'netflix.com'
-  ],
-
-  //  'forwardMapping' - Object where the key is the lowercase email address from
-  //   which to forward and the value is an array of email addresses to which to
-  //   send the message.
-  //
-  //   To match all email addresses on a domain, use a key without the name part
-  //   of an email address before the "at" symbol (i.e. `@example.com`).
-  //
-  //   To match a mailbox name on all domains, use a key without the "at" symbol
-  //   and domain part of an email address (i.e. `info`).
-  //
-  //   To match all email addresses matching no other mapping, use "@" as a key.
   forwardMapping: {
     "info@example.com": ["example.john@example.com", "example.jen@example.com"],
     "abuse@example.com": ["example.jim@example.com"],

--- a/lambda/config/blockedRecipients.txt
+++ b/lambda/config/blockedRecipients.txt
@@ -1,0 +1,11 @@
+spam@tylerwalts.com
+dood@tylerwalts.com
+adobe@tylerwalts.com
+larry@tylerwalts.com
+john@tylerwalts.com
+doe@tylerwalts.com
+walterstyler@tylerwalts.com
+fuckyou_tumblr@tylerwalts.com
+crestfield@tylerwalts.com
+definitions@tylerwalts.com
+bodog@tylerwalts.com

--- a/lambda/config/blockedSenderDomains.txt
+++ b/lambda/config/blockedSenderDomains.txt
@@ -1,0 +1,2 @@
+cheekychillies.com
+bougiebarks.com

--- a/lambda/config/blockedSenders.txt
+++ b/lambda/config/blockedSenders.txt
@@ -1,0 +1,8 @@
+bluesoleil@tylerwalts.com
+tyler@tylerwalts.com
+asdflkj@tylerwalts.com
+adobe@tylerwalts.com
+banggood@tylerwalts.com
+admin@tylerwalts.com
+tinyprints@tylerwalts.com
+robinhood@tylerwalts.com

--- a/lambda/config/brandKeywords.txt
+++ b/lambda/config/brandKeywords.txt
@@ -1,0 +1,7 @@
+Harbor Freight
+HarborFreight
+Amazon
+Walmart
+Costco
+PayPal
+Netflix

--- a/lambda/config/bulkMailHeaders.txt
+++ b/lambda/config/bulkMailHeaders.txt
@@ -1,0 +1,3 @@
+X-Node-Mail
+X-Delivery-Attempt-ID
+X-Attachment-Ref

--- a/lambda/config/subjectFilterKeywords.txt
+++ b/lambda/config/subjectFilterKeywords.txt
@@ -1,0 +1,14 @@
+Viagra
+Kamagra
+Levitra
+Keranique
+Cialis
+YOU PERVERT
+Omaha Steak
+Omaha-Steak
+Ace Hardware
+Walmart Points
+Pittsburg Tool
+BCBS Plan
+Costco Visit
+CVS Points

--- a/lambda/config/trustedBrandDomains.txt
+++ b/lambda/config/trustedBrandDomains.txt
@@ -1,0 +1,6 @@
+harborfreight.com
+amazon.com
+walmart.com
+costco.com
+paypal.com
+netflix.com

--- a/lambda/lib/filterSpam.js
+++ b/lambda/lib/filterSpam.js
@@ -1,0 +1,115 @@
+const AWS = require("aws-sdk");
+const config = require("../config.js");
+const { emitMetric, emitSpamMetric }  = require("./metrics.js");
+
+const spamKey = "SPAM";
+
+/**
+ * Filters out spam, if custom filter is enabled in config.
+ * Some basic filters are included below.
+ * To add more custom filters:
+ * 1. Create a function that emits metrics and returns true if spam is found.
+ * 2. Add a  call to your new function in the list below.
+ * 3. Consider contributing this back to the project in a PR!
+ */
+function filterSpam(data) {
+  let spam = false; // Flag to set by one or more of the filter checks.
+
+  // Only check for spam to drop if custom filter is configured
+  if (config.config.spamFilter == 2) {
+    console.log('Custom Spam Filter is enabled.  Running filters...');
+
+    // Get the SES notification object from the data event
+    const sesNotification = data.event.Records[0].ses;
+    console.log("SES Notification:\n", JSON.stringify(sesNotification, null, 2));
+
+    // Run through a series of filters.
+    if(filterBySESReceiptVerdicts(sesNotification.receipt)) spam = true;
+    if(filterBySubjectKeyword(sesNotification.mail.commonHeaders.subject)) spam = true;
+    if(filterByTargetRecipient(sesNotification.mail.destination[0])) spam = true;
+  }
+
+  // If the spam flag is still not set after all the spam filters, then forward the email.
+  if (!spam) {
+    return Promise.resolve(data);
+  } else {
+    // If the spam flag is set by any of the spam filters, then reject the promise to stop the forward.
+    data.log({
+      message: "Dropped Spam.",
+      level: "error",
+      event: JSON.stringify(data.event)
+    });
+    return Promise.reject(new Error(spamKey));
+  }
+}
+
+
+/**
+ * Filter By SES Receipt Verdicts
+ * The following logic is from AWS Docs and is also found in the default CDK dropSpam implementation.
+ * This function has the same impact as choosing spamFilter config = 1 = Default
+ * Docs:  https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-lambda-example-functions.html
+ **/
+function filterBySESReceiptVerdicts(sesReceipt) {
+  console.log("filterBySESverdicts");
+  const typeName = 'SESReceiptVerdict';
+  let spam = false;
+  if (sesReceipt.spfVerdict.status === 'FAIL') spam = logSpam(typeName, 'Sender Policy Framework (SPF)');
+  if (sesReceipt.dkimVerdict.status === 'FAIL') spam = logSpam(typeName, 'DomainKeys Identified Mail (DKIM)');
+  if (sesReceipt.spamVerdict.status === 'FAIL') spam = logSpam(typeName, 'AWS Spam Verdict');
+  if (sesReceipt.virusVerdict.status === 'FAIL') spam = logSpam(typeName, 'AWS Virus Verdict');
+  return spam;
+}
+
+
+/**
+ * Filter by Subject Keyword
+ * Given an email subject, tag it as spam if it contains any configured keywords.
+ **/
+function filterBySubjectKeyword(subject) {
+  console.log("filterBySubject");
+  const typeName = 'SubjectKeyword';
+  let spam = false;
+
+  for (let i = 0; i < config.config.subjectFilterKeywords.length; i++) {
+    const keyword = config.config.subjectFilterKeywords[i];
+    if (subject.toLowerCase().includes(keyword.toLowerCase())) spam = logSpam(typeName, keyword);
+  }
+
+  return spam;
+}
+
+
+/**
+ * Filter By Target Recipient will check the To: email value and drop any configured addresses.
+ * Use this if you want to give an email to someone you know will spam you (games, conferences).
+ **/
+function filterByTargetRecipient(recipientEmail) {
+  console.log("filterByTarget");
+  const typeName = 'TargetRecipient';
+  let spam = false;
+
+  for (const recipient of config.config.blockedRecipients) {
+    if (recipientEmail === recipient) spam = logSpam(typeName, recipient.replace('@', '.'));
+  }
+
+  return spam;
+}
+
+
+/**
+ * Log Spam emits a metric and returns true, to easily set the spam flag.
+ * The intent is to record metrics for every reason an email is determined to be spam.
+ **/
+function logSpam(type, term) {
+  console.log(`Logging spam, type=${type}, term=${term}`);
+  emitSpamMetric(type, term);
+  return true;
+}
+
+
+module.exports = {
+    filterSpam,
+    spamKey
+};
+

--- a/lambda/lib/filterSpam.js
+++ b/lambda/lib/filterSpam.js
@@ -27,6 +27,10 @@ function filterSpam(data) {
     if(filterBySESReceiptVerdicts(sesNotification.receipt)) spam = true;
     if(filterBySubjectKeyword(sesNotification.mail.commonHeaders.subject)) spam = true;
     if(filterByTargetRecipient(sesNotification.mail.destination[0])) spam = true;
+    if(filterBySender(sesNotification.mail.source)) spam = true;
+    if(filterBySenderDomain(sesNotification.mail.source)) spam = true;
+    warnBulkMailHeaders(sesNotification.mail);
+    if(filterByBrandImpersonation(sesNotification.mail.commonHeaders.from[0], sesNotification.mail.source)) spam = true;
   }
 
   // If the spam flag is still not set after all the spam filters, then forward the email.
@@ -91,6 +95,92 @@ function filterByTargetRecipient(recipientEmail) {
 
   for (const recipient of config.config.blockedRecipients) {
     if (recipientEmail === recipient) spam = logSpam(typeName, recipient.replace('@', '.'));
+  }
+
+  return spam;
+}
+
+
+/**
+ * Filter By Sender checks the full source email address against a blocklist.
+ **/
+function filterBySender(source) {
+  console.log("filterBySender");
+  const typeName = 'BlockedSender';
+  let spam = false;
+
+  const senderEmail = source.toLowerCase();
+  for (const blocked of config.config.blockedSenders) {
+    if (senderEmail === blocked.toLowerCase()) {
+      spam = logSpam(typeName, blocked);
+    }
+  }
+
+  return spam;
+}
+
+
+/**
+ * Filter By Sender Domain checks the source email domain against a blocklist.
+ **/
+function filterBySenderDomain(source) {
+  console.log("filterBySenderDomain");
+  const typeName = 'SenderDomain';
+  let spam = false;
+
+  const senderDomain = source.split('@').pop().toLowerCase();
+  for (const domain of config.config.blockedSenderDomains) {
+    if (senderDomain === domain.toLowerCase()) {
+      spam = logSpam(typeName, domain);
+    }
+  }
+
+  return spam;
+}
+
+
+/**
+ * Warn on Bulk Mail Headers — logs a warning when mass-mailer headers are
+ * detected but does NOT block the email.
+ **/
+function warnBulkMailHeaders(mail) {
+  const headerNames = mail.headers.map(h => h.name.toLowerCase());
+  for (const bulkHeader of config.config.bulkMailHeaders) {
+    if (headerNames.includes(bulkHeader.toLowerCase())) {
+      console.warn(JSON.stringify({
+        level: "warn",
+        message: "Bulk mail header detected",
+        header: bulkHeader,
+        sender: mail.source,
+        recipient: mail.destination[0],
+        subject: mail.commonHeaders.subject
+      }));
+    }
+  }
+}
+
+
+/**
+ * Filter By Brand Impersonation detects when the From display name contains
+ * a known brand keyword but the sender domain is not the brand's real domain.
+ **/
+function filterByBrandImpersonation(fromHeader, source) {
+  console.log("filterByBrandImpersonation");
+  const typeName = 'BrandImpersonation';
+  let spam = false;
+
+  const senderDomain = source.split('@').pop().toLowerCase();
+  const displayName = fromHeader.toLowerCase();
+
+  for (const brand of config.config.brandKeywords) {
+    if (displayName.includes(brand.toLowerCase())) {
+      const isTrusted = config.config.trustedBrandDomains.some(
+        d => senderDomain === d.toLowerCase() || senderDomain.endsWith('.' + d.toLowerCase())
+      );
+      if (!isTrusted) {
+        spam = logSpam(typeName, brand);
+      }
+    }
   }
 
   return spam;

--- a/lambda/lib/metrics.js
+++ b/lambda/lib/metrics.js
@@ -1,0 +1,104 @@
+var config = require("../config.js");
+
+const NAMESPACE_ROOT = `${config.config.project}/SESForwarder`;
+
+/**
+ * emitMetric to CloudWatch using Embedded Metric Format (EMF) of logging from Lambda.  For example:
+ *
+ * {"_aws":{"Timestamp":1611034887493,"CloudWatchMetrics":[{"Namespace":"MyDomain/SESForwarder/Spam",
+ * "Dimensions":[["Type"]],"Metrics":[{"Name":"Viagra","Unit":"Count"}]}]},"Viagra":1,"Type":"SubjectKeyword"}
+ *
+ * See: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html
+ * Also: https://aws.amazon.com/blogs/mt/lowering-costs-and-focusing-on-our-customers-with-amazon-cloudwatch-embedded-custom-metrics/
+ *
+ * Params:
+ *   metricName is a string name of metric.
+ *
+ *   dimensions is an array of dimension objets, following cloudwatch.putMetric schema.
+ *     For example:
+ *
+ *     const dimensions = [
+ *       {
+ *         Name: 'MyDimensionName',
+ *         Value: 'MyDimensionValue'
+ *       }
+ *     ];
+ *
+ *    namespace is a string of the CloudWatch namespace that metrics will be emitted under.
+ */
+function emitMetric(metricName, dimensions= [], namespace = NAMESPACE_ROOT) {
+  // The EMF log spec puts dimension keys inside the schema and values outside at root level.
+  // Build up a list of just the keys.
+  let dimensionKeys = [], dimensionsArray = [];
+  for (const dimension of dimensions){
+    dimensionKeys.push(dimension.Name);
+  }
+
+  // Create the EMF log structure following the spec.
+  let embeddedMetricLog = {
+    "_aws": {
+        "Timestamp": Date.now(),
+        "CloudWatchMetrics": [
+            {
+                "Namespace": namespace,
+                "Dimensions": [ dimensionKeys ],
+                "Metrics": [
+                    {
+                        "Name": metricName,
+                        "Unit": "Count"
+                    }
+                ]
+            }
+        ]
+    }
+  };
+
+  // Add the metric name and count as a root element, following EMF spec
+  embeddedMetricLog[metricName] = 1.0;
+
+  // Add the dimension mapping as root elements, following EMF spec.
+  for (const dimension of dimensions){
+    embeddedMetricLog[dimension.Name] = dimension.Value;
+  }
+
+  // When executing in Lambda, EMF spec just needs to be emitted as std output.
+  console.log(JSON.stringify(embeddedMetricLog));
+
+  // Return true to signal success logging metric
+  return true;
+}
+
+
+/**
+ * emitSpamMetric to CloudWatch using consistent namespace.
+ * Type is the type of spam reason, usually per filter type.
+ * Term is the specific term of this type that triggered the spam flag.
+ */
+function emitSpamMetric(type, term) {
+  const dimensions = [
+    {
+      Name: 'Type',
+      Value: type
+    },
+  ];
+
+  return emitMetric(term, dimensions, `${NAMESPACE_ROOT}/Spam`);
+}
+
+
+/**
+ * emitResultMetric to CloudWatch using consistent namespace.
+ * Result Examples: Success, Error, Spam, Other...
+ */
+function emitResultMetric(result) {
+  const dimensions = [];
+  return emitMetric(result, dimensions, `${NAMESPACE_ROOT}/Result`);
+}
+
+
+module.exports = {
+  emitMetric,
+  emitSpamMetric,
+  emitResultMetric
+};
+

--- a/lib/ses-stack.ts
+++ b/lib/ses-stack.ts
@@ -92,6 +92,7 @@ export class SesStack extends cdk.Stack {
         title: 'Total Incoming',
         width: 6,
         height: 3,
+        setPeriodToTimeRange: true,
         metrics: [new cloudwatch.Metric({
             namespace: "AWS/Lambda",
             metricName: 'Invocations',
@@ -107,6 +108,7 @@ export class SesStack extends cdk.Stack {
         title: 'Total Dropped',
         width: 6,
         height: 3,
+        setPeriodToTimeRange: true,
         metrics: [new cloudwatch.Metric({
             namespace: `${config.project}/SESForwarder/Result`,
             metricName: 'Spam',
@@ -119,6 +121,7 @@ export class SesStack extends cdk.Stack {
         title: 'Total Errors',
         width: 6,
         height: 3,
+        setPeriodToTimeRange: true,
         metrics: [new cloudwatch.Metric({
             namespace: `${config.project}/SESForwarder/Result`,
             metricName: 'Error',
@@ -131,6 +134,7 @@ export class SesStack extends cdk.Stack {
         title: 'Total Forwarded',
         width: 6,
         height: 3,
+        setPeriodToTimeRange: true,
         metrics: [new cloudwatch.Metric({
             namespace: `${config.project}/SESForwarder/Result`,
             metricName: 'Success',

--- a/lib/ses-stack.ts
+++ b/lib/ses-stack.ts
@@ -4,6 +4,7 @@ import lambda = require("@aws-cdk/aws-lambda");
 import s3 = require("@aws-cdk/aws-s3");
 import ses = require("@aws-cdk/aws-ses");
 import actions = require("@aws-cdk/aws-ses-actions");
+import cloudwatch = require('@aws-cdk/aws-cloudwatch');
 import path = require("path");
 
 import { SpamFilterOption, config } from "../lambda/config";
@@ -14,9 +15,10 @@ export class SesStack extends cdk.Stack {
 
     const bucket = new s3.Bucket(this, `${config.project}SESBucket`);
 
-    const func = new lambda.Function(this, `${config.project}SESForwarder`, {
+    const forwarderLambda = new lambda.Function(this, `${config.project}SESForwarder`, {
       runtime: lambda.Runtime.NODEJS_12_X,
       handler: "handler.handler",
+      functionName: `${config.project}SESForwarder`,
       code: lambda.Code.fromAsset(path.join(__dirname, "../lambda")),
       environment: {
         BUCKETNAME: bucket.bucketName
@@ -25,7 +27,7 @@ export class SesStack extends cdk.Stack {
       memorySize: 128
     });
 
-    const lambdaRole = func.role as iam.Role;
+    const lambdaRole = forwarderLambda.role as iam.Role;
 
     const policy = new iam.Policy(this, `${config.project}SESPolicy`);
 
@@ -70,12 +72,173 @@ export class SesStack extends cdk.Stack {
               bucket,
               objectKeyPrefix: config.emailKeyPrefix
             }),
-            new actions.Lambda({ function: func })
+            new actions.Lambda({ function: forwarderLambda })
           ]
         }
       ]
     };
 
     new ses.ReceiptRuleSet(this, `${config.project}RuleSet`, ruleSetProperties);
+
+
+    /* Define a CloudWatch Metrics Dashboard */
+
+    // Total Incoming
+    let totalIncomingWidget = new cloudwatch.SingleValueWidget({
+        title: 'Total Incoming',
+        width: 6,
+        height: 3,
+        metrics: [new cloudwatch.Metric({
+            namespace: "AWS/Lambda",
+            metricName: 'Invocations',
+            dimensions: {
+                FunctionName: forwarderLambda.functionName
+            },
+            statistic: 'Sum'
+        })]
+    });
+
+    // Total Dropped
+    let totalDroppedWidget = new cloudwatch.SingleValueWidget({
+        title: 'Total Dropped',
+        width: 6,
+        height: 3,
+        metrics: [new cloudwatch.Metric({
+            namespace: `${config.project}/SESForwarder/Result`,
+            metricName: 'Spam',
+            statistic: 'Sum'
+        })]
+    });
+
+    // Total Errors
+    let totalErrorsWidget = new cloudwatch.SingleValueWidget({
+        title: 'Total Errors',
+        width: 6,
+        height: 3,
+        metrics: [new cloudwatch.Metric({
+            namespace: `${config.project}/SESForwarder/Result`,
+            metricName: 'Error',
+            statistic: 'Sum'
+        })]
+    });
+
+    // Total Forwarded
+    let totalForwardedWidget = new cloudwatch.SingleValueWidget({
+        title: 'Total Forwarded',
+        width: 6,
+        height: 3,
+        metrics: [new cloudwatch.Metric({
+            namespace: `${config.project}/SESForwarder/Result`,
+            metricName: 'Success',
+            statistic: 'Sum'
+        })]
+    });
+
+    // Lambda Invocations and Duration
+    const executionsWidget = new cloudwatch.GraphWidget({
+        title: 'Forwarder Executions',
+        width: 12,
+        height: 3,
+        left: [new cloudwatch.Metric({
+            namespace: 'AWS/Lambda',
+            metricName: 'Invocations',
+            dimensions: {
+                FunctionName: forwarderLambda.functionName
+            },
+            statistic: 'Sum'
+        })],
+        right: [new cloudwatch.Metric({
+            namespace: 'AWS/Lambda',
+            metricName: 'Duration',
+            dimensions: {
+                FunctionName: forwarderLambda.functionName
+            },
+            statistic: 'Sum'
+        })],
+        rightYAxis: {
+            label: "Latency"
+        },
+    });
+
+    // Results
+    let resultWidget = new cloudwatch.GraphWidget({
+        title: 'Forwarder Results',
+        width: 12,
+        height: 3,
+        stacked: true,
+        left: [new cloudwatch.Metric({
+            namespace: `${config.project}/SESForwarder/Result`,
+            metricName: 'Error',
+            statistic: 'Sum'
+        }),
+        new cloudwatch.Metric({
+            namespace: `${config.project}/SESForwarder/Result`,
+            metricName: 'Spam',
+            statistic: 'Sum'
+        }),
+        new cloudwatch.Metric({
+            namespace: `${config.project}/SESForwarder/Result`,
+            metricName: 'Success',
+            statistic: 'Sum'
+        })]
+    });
+
+    // Spam Tags
+    let spamWidget = new cloudwatch.GraphWidget({
+        title: 'Spam Tags by Type',
+        width: 12,
+        height: 9,
+        left: [new cloudwatch.MathExpression({
+            expression: `SEARCH('{${config.project}/SESForwarder/Spam,Type}', 'Sum', 300)`,
+            usingMetrics: { },
+            label: ' '
+        })]
+    });
+
+    // Results
+    let sesWidget = new cloudwatch.GraphWidget({
+        title: 'Total Account SES Sends',
+        width: 12,
+        height: 3,
+        stacked: true,
+        left: [new cloudwatch.Metric({
+            namespace: 'AWS/SES',
+            metricName: 'Send',
+            statistic: 'Sum'
+        })]
+    });
+
+    // Recent logs
+    let queryLinesList = ['fields @timestamp, mail.commonHeaders.from.0, mail.destination.0, mail.commonHeaders.subject, ispresent(mail.commonHeaders.from.0) as fw'];
+    queryLinesList.push('filter fw != 0');
+    queryLinesList.push('sort @timestamp desc');
+    queryLinesList.push('limit 10');
+    let logWidget = new cloudwatch.LogQueryWidget({
+        title: 'Recent Forwarder Logs',
+        logGroupNames: [forwarderLambda.logGroup.logGroupName],
+        queryLines: queryLinesList,
+        width: 24,
+        height: 6
+    });
+
+    const emailDashboard = new cloudwatch.Dashboard(this, `${config.project}EmailDashboard`, {
+      dashboardName: `${config.project}-Email-Dashboard`,
+      widgets: [
+        [
+          new cloudwatch.Column(totalIncomingWidget),
+          new cloudwatch.Column(totalDroppedWidget),
+          new cloudwatch.Column(totalErrorsWidget),
+          new cloudwatch.Column(totalForwardedWidget),
+        ],
+        [
+          new cloudwatch.Column(executionsWidget, resultWidget, sesWidget),
+          new cloudwatch.Column(spamWidget),
+        ],
+        [
+          logWidget
+        ]
+      ]
+    });
+
   }
 }

--- a/lib/ses-stack.ts
+++ b/lib/ses-stack.ts
@@ -13,7 +13,22 @@ export class SesStack extends cdk.Stack {
   constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    const bucket = new s3.Bucket(this, `${config.project}SESBucket`);
+    const bucket = new s3.Bucket(this, `${config.project}SESBucket`, {
+        lifecycleRules: [
+          {
+            transitions: [
+                {
+                    storageClass: s3.StorageClass.INFREQUENT_ACCESS,
+                    transitionAfter: cdk.Duration.days(30),
+                },
+                {
+                    storageClass: s3.StorageClass.GLACIER,
+                    transitionAfter: cdk.Duration.days(90),
+                },
+            ],
+          },
+        ],
+    });
 
     const forwarderLambda = new lambda.Function(this, `${config.project}SESForwarder`, {
       runtime: lambda.Runtime.NODEJS_12_X,

--- a/lib/ses-stack.ts
+++ b/lib/ses-stack.ts
@@ -63,6 +63,7 @@ export class SesStack extends cdk.Stack {
       rules: [
         {
           enabled: true,
+          recipients: [ `.${config.domain}`, config.domain ],
           actions: [
             new actions.AddHeader({
               name: "X-Special-Header",
@@ -72,7 +73,10 @@ export class SesStack extends cdk.Stack {
               bucket,
               objectKeyPrefix: config.emailKeyPrefix
             }),
-            new actions.Lambda({ function: forwarderLambda })
+            new actions.Lambda({
+              function: forwarderLambda
+            }),
+            new actions.Stop({})
           ]
         }
       ]

--- a/lib/ses-stack.ts
+++ b/lib/ses-stack.ts
@@ -6,7 +6,7 @@ import ses = require("@aws-cdk/aws-ses");
 import actions = require("@aws-cdk/aws-ses-actions");
 import path = require("path");
 
-import { config } from "../lambda/config";
+import { SpamFilterOption, config } from "../lambda/config";
 
 export class SesStack extends cdk.Stack {
   constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
@@ -55,12 +55,12 @@ export class SesStack extends cdk.Stack {
     );
     lambdaRole.attachInlinePolicy(policy);
 
-    new ses.ReceiptRuleSet(this, `${config.project}RuleSet`, {
-      dropSpam: true,
+    if (config.spamFilter == SpamFilterOption.NONE) console.warn("Warning: you are not using any spam filter!");
+    const ruleSetProperties = {
+      dropSpam: config.spamFilter == SpamFilterOption.DEFAULT ? true : false,
       rules: [
         {
           enabled: true,
-          recipients: [config.recipient],
           actions: [
             new actions.AddHeader({
               name: "X-Special-Header",
@@ -74,6 +74,8 @@ export class SesStack extends cdk.Stack {
           ]
         }
       ]
-    });
+    };
+
+    new ses.ReceiptRuleSet(this, `${config.project}RuleSet`, ruleSetProperties);
   }
 }


### PR DESCRIPTION

  ## Summary

  - Add blocked sender email filter (exact match on `mail.source`)
  - Add blocked sender domain filter (domain-level match)
  - Add brand impersonation filter (From display name vs actual sender domain)
  - Add bulk mail header warning (logs but does not block)
  - Refactor all blocklists into separate `.txt` files under `lambda/config/` for easy editing
  - Add CloudWatch Insights queries and spam filter documentation to README

  ## Test plan

  - [ ] Run CloudWatch Insights queries against 3 months of logs to validate impact before deploy
  - [ ] Copy `config.example.js` to `config.js`, verify `npx cdk synth` succeeds
  - [ ] Deploy to dev/staging and send test emails to confirm forwarding still works
  - [ ] Verify spam metrics appear in CloudWatch under `TylerWalts/SESForwarder/Spam`
